### PR TITLE
Bug fix for fishnet grid recipe: Points of LinearRing did not form a clo...

### DIFF
--- a/vector_layers.rst
+++ b/vector_layers.rst
@@ -862,6 +862,7 @@ This recipe creates a fishnet grid.
                 ring.AddPoint(ringXrightOrigin, ringYtop)
                 ring.AddPoint(ringXrightOrigin, ringYbottom)
                 ring.AddPoint(ringXleftOrigin, ringYbottom)
+                ring.AddPoint(ringXleftOrigin, ringYtop)
                 poly = ogr.Geometry(ogr.wkbPolygon)
                 poly.AddGeometry(ring)
 


### PR DESCRIPTION
...sed linestring.

First point creating a ring, also needs to be the last point, otherwise the ring is not closed.
