### PR TITLE
Print functions compatible with python 2 or 3

### DIFF
--- a/gdal_general.rst
+++ b/gdal_general.rst
@@ -75,9 +75,9 @@ Only works with GDAL version >= 1.10
         }
         err_msg = err_msg.replace('\n',' ')
         err_class = errtype.get(err_class, 'None')
-        print 'Error Number: %s' % (err_num)
-        print 'Error Type: %s' % (err_class)
-        print 'Error Message: %s' % (err_msg)
+        print('Error Number: %s' % (err_num))
+        print('Error Type: %s' % (err_class))
+        print('Error Message: %s' % (err_msg))
         
     if __name__=='__main__':
         

--- a/geometry.rst
+++ b/geometry.rst
@@ -9,7 +9,7 @@ Create a Point
     from osgeo import ogr
     point = ogr.Geometry(ogr.wkbPoint)
     point.AddPoint(1198054.34, 648493.09)
-    print point.ExportToWkt()
+    print(point.ExportToWkt())
 
 Create a LineString
 -------------------
@@ -22,7 +22,7 @@ Create a LineString
     line.AddPoint(1188804.0108498496, 652655.7409537067)
     line.AddPoint(1226730.3625203592, 634155.0816022386) 
     line.AddPoint(1281307.30760719, 636467.6640211721)
-    print line.ExportToWkt()
+    print(line.ExportToWkt())
 
 Create a Polygon
 ----------------
@@ -44,7 +44,7 @@ Create a Polygon
     poly = ogr.Geometry(ogr.wkbPolygon)
     poly.AddGeometry(ring)
 
-    print poly.ExportToWkt()
+    print(poly.ExportToWkt())
 
 Create a Polygon with holes
 ----------------------------
@@ -74,7 +74,7 @@ Create a Polygon with holes
     poly.AddGeometry(outRing)
     poly.AddGeometry(innerRing)
 
-    print poly.ExportToWkt()
+    print(poly.ExportToWkt())
 
 Create a MultiPoint
 -------------------
@@ -97,7 +97,7 @@ Create a MultiPoint
     point3.AddPoint(1250318.7031934808, 606404.0925750365)
     multipoint.AddGeometry(point3)
 
-    print multipoint.ExportToWkt()
+    print(multipoint.ExportToWkt())
 
 Create a MultiLineString
 ------------------------
@@ -118,7 +118,7 @@ Create a MultiLineString
     line1.AddPoint(1219792.6152635587, 606866.6090588232)
     multiline.AddGeometry(line1)
 
-    print multiline.ExportToWkt()
+    print(multiline.ExportToWkt())
 
 Create a MultiPolygon
 ---------------------
@@ -155,7 +155,7 @@ Create a MultiPolygon
     poly2.AddGeometry(ring2)
     multipolygon.AddGeometry(poly2)
 
-    print multipolygon.ExportToWkt()
+    print(multipolygon.ExportToWkt())
 
 Create a GeometryCollection
 ---------------------------
@@ -178,7 +178,7 @@ Create a GeometryCollection
     line.AddPoint(-122.48, 47.23)
     geomcol.AddGeometry(line)
 
-    print geomcol.ExportToWkt()
+    print(geomcol.ExportToWkt())
 
 Create Geometry from WKT
 ------------------------
@@ -189,7 +189,7 @@ Create Geometry from WKT
 
     wkt = "POINT (1120351.5712494177 741921.4223245403)"
     point = ogr.CreateGeometryFromWkt(wkt)
-    print "%d,%d" % (point.GetX(), point.GetY())
+    print("%d,%d" % (point.GetX(), point.GetY()))
 
 Create Geometry from GeoJSON
 ----------------------------
@@ -200,7 +200,7 @@ Create Geometry from GeoJSON
 
     geojson = """{"type":"Point","coordinates":[108420.33,753808.59]}"""
     point = ogr.CreateGeometryFromJson(geojson)
-    print "%d,%d" % (point.GetX(), point.GetY())
+    print("%d,%d" % (point.GetX(), point.GetY()))
 
 Create Geometry from GML
 ------------------------
@@ -211,7 +211,7 @@ Create Geometry from GML
 
     gml = """<gml:Point xmlns:gml="http://www.opengis.net/gml"><gml:coordinates>108420.33,753808.59</gml:coordinates></gml:Point>"""
     point = ogr.CreateGeometryFromGML(gml)
-    print "%d,%d" % (point.GetX(), point.GetY())
+    print("%d,%d" % (point.GetX(), point.GetY()))
 
 Create Geometry from WKB
 ------------------------
@@ -223,7 +223,7 @@ Create Geometry from WKB
 
     wkb = b64decode("AIAAAAFBMkfmVwo9cUEjylouFHrhAAAAAAAAAAA=")
     point = ogr.CreateGeometryFromWkb(wkb)
-    print "%d,%d" % (point.GetX(), point.GetY())
+    print("%d,%d" % (point.GetX(), point.GetY()))
 
 Count Points in a Geometry
 --------------------------
@@ -234,7 +234,7 @@ Count Points in a Geometry
 
     wkt = "LINESTRING (1181866.263593049 615654.4222507705, 1205917.1207499576 623979.7189589312, 1227192.8790041457 643405.4112779726, 1224880.2965852122 665143.6860159477)"
     geom = ogr.CreateGeometryFromWkt(wkt)
-    print "Geometry has %i points" % (geom.GetPointCount())
+    print("Geometry has %i points" % (geom.GetPointCount()))
 
 Count Geometries in a Geometry
 -------------------------------
@@ -245,7 +245,7 @@ Count Geometries in a Geometry
 
     wkt = "MULTIPOINT (1181866.263593049 615654.4222507705, 1205917.1207499576 623979.7189589312, 1227192.8790041457 643405.4112779726, 1224880.2965852122 665143.6860159477)"
     geom = ogr.CreateGeometryFromWkt(wkt)
-    print "Geometry has %i geometries" % (geom.GetGeometryCount())
+    print("Geometry has %i geometries" % (geom.GetGeometryCount()))
 
 Iterate over Geometries in a Geometry
 -------------------------------------
@@ -258,7 +258,7 @@ Iterate over Geometries in a Geometry
     geom = ogr.CreateGeometryFromWkt(wkt)
     for i in range(0, geom.GetGeometryCount()):
         g = geom.GetGeometryRef(i)
-        print "%i). %s" %(i, g.ExportToWkt())
+        print("%i). %s" %(i, g.ExportToWkt()))
 
 
 Iterate over Points in a Geometry
@@ -273,7 +273,7 @@ Iterate over Points in a Geometry
     for i in range(0, geom.GetPointCount()):
         # GetPoint returns a tuple not a Geometry
         pt = geom.GetPoint(i)
-        print "%i). POINT (%d %d)" %(i, pt[0], pt[1])
+        print("%i). POINT (%d %d)" %(i, pt[0], pt[1]))
 
 Buffer a Geometry
 -----------------
@@ -286,7 +286,7 @@ Buffer a Geometry
     pt = ogr.CreateGeometryFromWkt(wkt)
     bufferDistance = 500
     poly = pt.Buffer(bufferDistance)
-    print "%s buffered by %d is %s" % (pt.ExportToWkt(), bufferDistance, poly.ExportToWkt())
+    print("%s buffered by %d is %s" % (pt.ExportToWkt(), bufferDistance, poly.ExportToWkt()))
 
 Calculate Envelope of a Geometry
 --------------------------------
@@ -299,7 +299,7 @@ Calculate Envelope of a Geometry
     geom = ogr.CreateGeometryFromWkt(wkt)
     # Get Envelope returns a tuple (minX, maxX, minY, maxY)
     env = geom.GetEnvelope()
-    print "minX: %d, minY: %d, maxX: %d, maxY: %d" %(env[0],env[2],env[1],env[3])
+    print("minX: %d, minY: %d, maxX: %d, maxY: %d" %(env[0],env[2],env[1],env[3]))
 
 
 Calculate the Area of a Geometry
@@ -311,7 +311,7 @@ Calculate the Area of a Geometry
 
     wkt = "POLYGON ((1162440.5712740074 672081.4332727483, 1162440.5712740074 647105.5431482664, 1195279.2416228633 647105.5431482664, 1195279.2416228633 672081.4332727483, 1162440.5712740074 672081.4332727483))"
     poly = ogr.CreateGeometryFromWkt(wkt)
-    print "Area = %d" % poly.GetArea()
+    print("Area = %d" % poly.GetArea())
 
 Calculate the Length of a Geometry
 ----------------------------------
@@ -322,7 +322,7 @@ Calculate the Length of a Geometry
 
     wkt = "LINESTRING (1181866.263593049 615654.4222507705, 1205917.1207499576 623979.7189589312, 1227192.8790041457 643405.4112779726, 1224880.2965852122 665143.6860159477)"
     geom = ogr.CreateGeometryFromWkt(wkt)
-    print "Length = %d" % geom.Length()
+    print("Length = %d" % geom.Length())
 
 Get the geometry type (as a string) from a Geometry
 ---------------------------------------------------
@@ -339,7 +339,7 @@ Get the geometry type (as a string) from a Geometry
 
     for wkt in wkts:
         geom = ogr.CreateGeometryFromWkt(wkt)
-        print geom.GetGeometryName()
+        print(geom.GetGeometryName())
 
 Calculate intersection between two Geometries
 ---------------------------------------------
@@ -356,7 +356,7 @@ Calculate intersection between two Geometries
 
     intersection = poly1.Intersection(poly2)
 
-    print intersection.ExportToWkt()
+    print(intersection.ExportToWkt())
 
 Calculate union between two Geometries
 --------------------------------------
@@ -373,16 +373,16 @@ Calculate union between two Geometries
 
     union = poly1.Union(poly2)
 
-    print poly1
-    print poly2
-    print union.ExportToWkt()
+    print(poly1)
+    print(poly2)
+    print(union.ExportToWkt())
 
 Write Geometry to GeoJSON
 -------------------------
 
 There are two options to create a GeoJSON from a geometry.
 
-You can either create a new GeoJSON file or simply export the geometry to Json and print it. Both options are explained below.
+You can either create a new GeoJSON file or simply export the geometry to Json and print(it. Both options are explained below.)
 
 .. code-block:: python
 
@@ -440,7 +440,7 @@ You can either create a new GeoJSON file or simply export the geometry to Json a
     poly.AddGeometry(ring)
     
     geojson = poly.ExportToJson()
-    print geojson
+    print(geojson)
 
 Write Geometry to WKT
 ---------------------
@@ -462,7 +462,7 @@ Write Geometry to WKT
 
     # Export geometry to WKT
     wkt = geom_poly.ExportToWkt()
-    print wkt
+    print(wkt)
 
 Write Geometry to KML
 ---------------------
@@ -483,7 +483,7 @@ Write Geometry to KML
     geom_poly.AddGeometry(ring)
     
     kml = geom_poly.ExportToKML()
-    print kml
+    print(kml)
 
 Write Geometry to WKB
 ---------------------
@@ -505,7 +505,7 @@ Write Geometry to WKB
 
     # Export geometry to WKT
     wkb = geom_poly.ExportToWkb()
-    print wkb
+    print(wkb)
 
 
 Force polygon to multipolygon
@@ -527,7 +527,7 @@ Force polygon to multipolygon
 
     # Then export geometry to WKT
     wkt = geom_poly.ExportToWkt()
-    print wkt
+    print(wkt)
 
 
 Quarter polygon and create centroids

--- a/gotchas.rst
+++ b/gotchas.rst
@@ -28,7 +28,7 @@ If you read the documentation for any of the filter setters you will see the cav
     lyr.SetAttributeFilter("PIN = '0000200001'")      # this is a unique attribute filter targeting only one record
     for i in range( 0, lyr.GetFeatureCount() ):       
         feat = lyr.GetFeature( i )
-        print feat                                    # this will print one feat, but it's the first feat in the Layer and NOT our target filtered feat  
+        print(feat)                                    # this will print one feat, but it's the first feat in the Layer and NOT our target filtered feat  
 
 Iterating over features
 .......................
@@ -38,10 +38,10 @@ You can treat a layer as an iterator, which calls GetNextFeature().  Iterating o
 .. code-block:: python
 
     for feature in layer:
-        print feature.GetField("STATE_NAME")
+        print(feature.GetField("STATE_NAME"))
     layer.ResetReading()
     for feature in layer:
-        print feature.GetField("STATE_NAME")
+        print(feature.GetField("STATE_NAME"))
 
 Features and Geometries Have a Relationship You Don't Want to Break
 -----------------------------------------------------------------------
@@ -53,7 +53,7 @@ The official gotchas have a good section on why `Python crashes when deleting fe
     from osgeo import ogr
     dSource = ogr.Open( "parcel_address.shp" )
     if dSource is None:
-        print "[ ERROR ]: datasource cannot be opened"
+        print("[ ERROR ]: datasource cannot be opened")
     layer = dSource.GetLayer()
     geom_collection = []
 
@@ -71,7 +71,7 @@ The official gotchas have a good section on why `Python crashes when deleting fe
     #  geometries collected
     #
     for g in geom_collection: 
-        print g.ExportToWkt()
+        print(g.ExportToWkt())
 
         <..PYTHON CRASHES..>
 

--- a/projection.rst
+++ b/projection.rst
@@ -30,7 +30,7 @@ Reproject a Geometry
     point = ogr.CreateGeometryFromWkt("POINT (1120351.57 741921.42)")
     point.Transform(transform)
 
-    print point.ExportToWkt()
+    print(point.ExportToWkt())
 
 Get Projection
 --------------

--- a/raster_layers.rst
+++ b/raster_layers.rst
@@ -28,7 +28,7 @@ Get raster metadata for quick-and-dirty resolution checks
 
     from osgeo import gdal
     gtif = gdal.Open( "INPUT.tif" )
-    print gtif.GetMetadata()
+    print(gtif.GetMetadata())
 
 
 Get Raster Band 
@@ -46,16 +46,16 @@ Get a raster band. Notice how we are handling runtime errors this function might
     try:
         src_ds = gdal.Open( "INPUT.tif" )
     except RuntimeError, e:
-        print 'Unable to open INPUT.tif'
-        print e
+        print('Unable to open INPUT.tif')
+        print(e)
         sys.exit(1)
 
     try:
         srcband = src_ds.GetRasterBand(1)
     except RuntimeError, e:
         # for example, try GetRasterBand(10)
-        print 'Band ( %i ) not found' % band_num
-        print e
+        print('Band ( %i ) not found' % band_num)
+        print(e)
         sys.exit(1)
 
 Loop Through All Raster Bands
@@ -70,13 +70,13 @@ Loop through all raster bands and do something useful like listing band statisti
 
     src_ds = gdal.Open( "INPUT.tif" )
     if src_ds is None:
-        print 'Unable to open INPUT.tif'
+        print('Unable to open INPUT.tif')
         sys.exit(1)
 
-    print "[ RASTER BAND COUNT ]: ", src_ds.RasterCount
+    print("[ RASTER BAND COUNT ]: ", src_ds.RasterCount)
     for band in range( src_ds.RasterCount ):
         band += 1
-        print "[ GETTING BAND ]: ", band
+        print("[ GETTING BAND ]: ", band)
         srcband = src_ds.GetRasterBand(band)
         if srcband is None:
             continue
@@ -85,7 +85,7 @@ Loop through all raster bands and do something useful like listing band statisti
         if stats is None:
             continue
 
-        print "[ STATS ] =  Minimum=%.3f, Maximum=%.3f, Mean=%.3f, StdDev=%.3f" % ( \
+        print("[ STATS ] =  Minimum=%.3f, Maximum=%.3f, Mean=%.3f, StdDev=%.3f" % ( \)
                     stats[0], stats[1], stats[2], stats[3] )
 
 
@@ -111,39 +111,39 @@ write a script that dumps out single band information
     def main( band_num, input_file ):
         src_ds = gdal.Open( input_file )
         if src_ds is None:
-            print 'Unable to open %s' % input_file
+            print('Unable to open %s' % input_file)
             sys.exit(1)
 
         try:
             srcband = src_ds.GetRasterBand(band_num)
         except RuntimeError, e:
-            print 'No band %i found' % band_num
-            print e
+            print('No band %i found' % band_num)
+            print(e)
             sys.exit(1)
 
 
-        print "[ NO DATA VALUE ] = ", srcband.GetNoDataValue()
-        print "[ MIN ] = ", srcband.GetMinimum()
-        print "[ MAX ] = ", srcband.GetMaximum()
-        print "[ SCALE ] = ", srcband.GetScale()
-        print "[ UNIT TYPE ] = ", srcband.GetUnitType()
+        print("[ NO DATA VALUE ] = ", srcband.GetNoDataValue())
+        print("[ MIN ] = ", srcband.GetMinimum())
+        print("[ MAX ] = ", srcband.GetMaximum())
+        print("[ SCALE ] = ", srcband.GetScale())
+        print("[ UNIT TYPE ] = ", srcband.GetUnitType())
         ctable = srcband.GetColorTable()
         
         if ctable is None:
-            print 'No ColorTable found'
+            print('No ColorTable found')
             sys.exit(1)
         
-        print "[ COLOR TABLE COUNT ] = ", ctable.GetCount()
+        print("[ COLOR TABLE COUNT ] = ", ctable.GetCount())
         for i in range( 0, ctable.GetCount() ):
             entry = ctable.GetColorEntry( i )
             if not entry:
                 continue
-            print "[ COLOR ENTRY RGB ] = ", ctable.GetColorEntryAsRGB( i, entry )
+            print("[ COLOR ENTRY RGB ] = ", ctable.GetColorEntryAsRGB( i, entry ))
 
     if __name__ == '__main__':
 
         if len( sys.argv ) < 3:
-            print """
+            print(""")
             [ ERROR ] you must supply at least two arguments: 
             1) the band number to retrieve and 2) input raster
             """
@@ -179,15 +179,15 @@ The raster we are going to polygonize:
     #
     src_ds = gdal.Open( "INPUT.tif" )
     if src_ds is None:
-        print 'Unable to open %s' % src_filename
+        print('Unable to open %s' % src_filename)
         sys.exit(1)
 
     try:
         srcband = src_ds.GetRasterBand(3)
     except RuntimeError, e:
         # for example, try GetRasterBand(10)
-        print 'Band ( %i ) not found' % band_num
-        print e
+        print('Band ( %i ) not found' % band_num)
+        print(e)
         sys.exit(1)
 
     #
@@ -370,7 +370,7 @@ Before Image: the input Natural Earth 10m geotiff with the timezone overlay we w
         #
         xoffset =  ulX 
         yoffset =  ulY
-        print "Xoffset, Yoffset = ( %f, %f )" % ( xoffset, yoffset )
+        print("Xoffset, Yoffset = ( %f, %f )" % ( xoffset, yoffset ))
 
         # Create a new geomatrix for the image
         geoTrans = list(geoTrans)
@@ -435,7 +435,7 @@ Before Image: the input Natural Earth 10m geotiff with the timezone overlay we w
         # example run : $ python clip.py /<full-path>/<shapefile-name>.shp /<full-path>/<raster-name>.tif
         #
         if len( sys.argv ) < 2:
-            print "[ ERROR ] you must two args. 1) the full shapefile path and 2) the full raster path"
+            print("[ ERROR ] you must two args. 1) the full shapefile path and 2) the full raster path")
             sys.exit( 1 )
 
         main( sys.argv[1], sys.argv[2] )
@@ -573,10 +573,10 @@ While this recipe works and is a good example, it is generally recommended to us
         #
     
         if len( sys.argv ) != 3:
-            print "[ ERROR ] you must supply two arguments: input-zone-shapefile-name.shp input-value-raster-name.tif "
+            print("[ ERROR ] you must supply two arguments: input-zone-shapefile-name.shp input-value-raster-name.tif ")
             sys.exit( 1 )
-        print 'Returns for each feature a dictionary item (FID) with the statistical values in the following order: Average, Mean, Medain, Standard Deviation, Variance'
-        print main( sys.argv[1], sys.argv[2] )
+        print('Returns for each feature a dictionary item (FID) with the statistical values in the following order: Average, Mean, Medain, Standard Deviation, Variance')
+        print(main( sys.argv[1], sys.argv[2] ))
     
 
 
@@ -619,7 +619,7 @@ This recipe converts raster pixels with a specified value to vector lines. For e
 	    geotransform = raster.GetGeoTransform()
 	    pixelWidth = geotransform[1] 
 	    maxDistance = ceil(sqrt(2*pixelWidth*pixelWidth))
-	    print maxDistance
+	    print(maxDistance)
     
 	    # array2dict
 	    count = 0

--- a/vector_layers.rst
+++ b/vector_layers.rst
@@ -24,9 +24,9 @@ Is Ogr Installed
 
     try:
       from osgeo import ogr
-      print 'Import of ogr from osgeo worked.  Hurray!\n'
+      print('Import of ogr from osgeo worked.  Hurray!\n')
     except:
-      print 'Import of ogr from osgeo failed\n\n'
+      print('Import of ogr from osgeo failed\n\n')
 
 View Auto Generated Ogr Help
 ------------------------------      
@@ -36,7 +36,7 @@ View Auto Generated Ogr Help
 .. code-block:: python
     
     import osgeo.ogr
-    print help(osgeo.ogr)
+    print(help(osgeo.ogr))
 
 Get List of Ogr Drivers Alphabetically (A- Z)
 -----------------------------------------------
@@ -58,7 +58,7 @@ Get List of Ogr Drivers Alphabetically (A- Z)
     formatsList.sort() # Sorting the messy list of ogr drivers 
 
     for i in formatsList:
-        print i
+        print(i)
      
 Is Ogr Driver Available by Driver Name
 --------------------------------------------      
@@ -74,33 +74,33 @@ Is Ogr Driver Available by Driver Name
     driverName = "ESRI Shapefile"
     drv = ogr.GetDriverByName( driverName )
     if drv is None:
-        print "%s driver not available.\n" % driverName
+        print("%s driver not available.\n" % driverName)
     else:
-        print  "%s driver IS available.\n" % driverName
+        print("%s driver IS available.\n" % driverName)
         
     ## PostgreSQL available?
     driverName = "PostgreSQL"
     drv = ogr.GetDriverByName( driverName )
     if drv is None:
-        print "%s driver not available.\n" % driverName
+        print("%s driver not available.\n" % driverName)
     else:
-        print  "%s driver IS available.\n" % driverName
+        print("%s driver IS available.\n" % driverName)
         
     ## Is File GeoDatabase available?
     driverName = "FileGDB"
     drv = ogr.GetDriverByName( driverName )
     if drv is None:
-        print "%s driver not available.\n" % driverName
+        print("%s driver not available.\n" % driverName)
     else:
-        print  "%s driver IS available.\n" % driverName
+        print("%s driver IS available.\n" % driverName)
         
     ## SDE available?
     driverName = "SDE"
     drv = ogr.GetDriverByName( driverName )
     if drv is None:
-        print "%s driver not available.\n" % driverName
+        print("%s driver not available.\n" % driverName)
     else:
-        print  "%s driver IS available.\n" % driverName
+        print("%s driver IS available.\n" % driverName)
 
 
 Force Ogr Use Named Driver 
@@ -149,12 +149,12 @@ Get Shapefile Feature Count
 
     # Check to see if shapefile is found.
     if dataSource is None:
-        print 'Could not open %s' % (daShapefile)
+        print('Could not open %s' % (daShapefile))
     else:
-        print 'Opened %s' % (daShapefile)
+        print('Opened %s' % (daShapefile))
         layer = dataSource.GetLayer()
         featureCount = layer.GetFeatureCount()  
-        print "Number of features in %s: %d" % (os.path.basename(daShapefile),featureCount)
+        print("Number of features in %s: %d" % (os.path.basename(daShapefile),featureCount))
 
         
     
@@ -186,7 +186,7 @@ Get All PostGIS layers in a PostgreSQL Database
     layerList.sort()
 
     for j in layerList:
-        print j
+        print(j)
 
     # Close connection
     conn = None
@@ -216,7 +216,7 @@ Get PostGIS Layer Feature Count By Layer Name
             sys.exit( 1 )
 
         featureCount = lyr.GetFeatureCount()
-        print "Number of features in %s: %d" % ( lyr_name , featureCount )
+        print("Number of features in %s: %d" % ( lyr_name , featureCount ))
 
         # Close connection
         conn = None
@@ -256,7 +256,7 @@ Get all layers in an Esri File GeoDataBase
     try:
         gdb = driver.Open(gdb_path, 0)
     except Exception, e:
-        print e
+        print(e)
         sys.exit()
 
     # list to store layers'names
@@ -272,7 +272,7 @@ Get all layers in an Esri File GeoDataBase
 
     # printing
     for featsClass in featsClassList:
-        print featsClass
+        print(featsClass)
         
     # clean close
     del gdb
@@ -318,7 +318,7 @@ Iterate over Features
     layer = dataSource.GetLayer()
 
     for feature in layer:
-        print feature.GetField("STATE_NAME")
+        print(feature.GetField("STATE_NAME"))
     layer.ResetReading()
 
 You must call `ResetReading <http://gdal.org/python/osgeo.ogr.Layer-class.html#ResetReading>`_ if you want to start iterating over the layer again.
@@ -338,7 +338,7 @@ Get Geometry from each Feature in a Layer
 
     for feature in layer:
         geom = feature.GetGeometryRef()
-        print geom.Centroid().ExportToWkt()
+        print(geom.Centroid().ExportToWkt())
 
 Filter by attribute
 ----------------------
@@ -356,7 +356,7 @@ Filter by attribute
     layer.SetAttributeFilter("SUB_REGION = 'Pacific'")
 
     for feature in layer:
-        print feature.GetField("STATE_NAME")
+        print(feature.GetField("STATE_NAME"))
 
 Spatial Filter
 -----------------
@@ -375,7 +375,7 @@ Spatial Filter
     layer.SetSpatialFilter(ogr.CreateGeometryFromWkt(wkt))
 
     for feature in layer:
-        print feature.GetField("STATE_NAME")
+        print(feature.GetField("STATE_NAME"))
 
 Get Shapefile Fields - Get the user defined fields
 ------------------------------------------------------
@@ -394,7 +394,7 @@ Get Shapefile Fields - Get the user defined fields
 
 
     for i in range(layerDefinition.GetFieldCount()):
-        print layerDefinition.GetFieldDefn(i).GetName() 
+        print(layerDefinition.GetFieldDefn(i).GetName() )
 
         
         
@@ -414,7 +414,7 @@ Get Shapefile Fields and Types - Get the user defined fields
     layerDefinition = daLayer.GetLayerDefn()
 
 
-    print "Name  -  Type  Width  Precision"
+    print("Name  -  Type  Width  Precision")
     for i in range(layerDefinition.GetFieldCount()):
         fieldName =  layerDefinition.GetFieldDefn(i).GetName()
         fieldTypeCode = layerDefinition.GetFieldDefn(i).GetType()
@@ -422,7 +422,7 @@ Get Shapefile Fields and Types - Get the user defined fields
         fieldWidth = layerDefinition.GetFieldDefn(i).GetWidth()
         GetPrecision = layerDefinition.GetFieldDefn(i).GetPrecision()
 
-        print fieldName + " - " + fieldType+ " " + str(fieldWidth) + " " + str(GetPrecision)  
+        print(fieldName + " - " + fieldType+ " " + str(fieldWidth) + " " + str(GetPrecision)  )
  
 
 Get PostGIS Layer Fields - Get the user defined fields
@@ -454,7 +454,7 @@ Get PostGIS Layer Fields - Get the user defined fields
 
 
         for i in range( lyrDefn.GetFieldCount() ):
-            print lyrDefn.GetFieldDefn( i ).GetName()
+            print(lyrDefn.GetFieldDefn( i ).GetName())
 
         # Close connection
         conn = None
@@ -503,7 +503,7 @@ Get PostGIS Layer Fields and Types - Get the user defined fields
             fieldWidth = lyrDefn.GetFieldDefn(i).GetWidth()
             GetPrecision = lyrDefn.GetFieldDefn(i).GetPrecision()
 
-            print fieldName + " - " + fieldType+ " " + str(fieldWidth) + " " + str(GetPrecision)
+            print(fieldName + " - " + fieldType+ " " + str(fieldWidth) + " " + str(GetPrecision))
 
         # Close connection
         conn = None
@@ -586,7 +586,7 @@ configuration to using WFS paging if it is supported.
     for i in range(wfs_ds.GetLayerCount()):
         layer = wfs_ds.GetLayerByIndex(i)
         srs = layer.GetSpatialRef()
-        print 'Layer: %s, Features: %s, SR: %s...' % (layer.GetName(), layer.GetFeatureCount(), srs.ExportToWkt()[0:50])
+        print('Layer: %s, Features: %s, SR: %s...' % (layer.GetName(), layer.GetFeatureCount(), srs.ExportToWkt()[0:50]))
 
         # iterate over features
         feat = layer.GetNextFeature()
@@ -634,7 +634,7 @@ More information about the GDAL HTTP proxy options can be found `here <http://tr
     lyr = ds.GetLayer('OGRGeoJSON')
     for feat in lyr:
         geom = feat.GetGeometryRef()
-        print geom.ExportToWkt()
+        print(geom.ExportToWkt())
 
 Read a CSV of Coordinates as an OGRVRTLayer
 ------------------------------------------------
@@ -666,7 +666,7 @@ Our OGRVRTLayer XML file called `example_wrapper.vrt` looks like this:
         </OGRVRTLayer>
     </OGRVRTDataSource>
 
-Now let's print out the point geometries:
+Now let's print(out the point geometries:)
 
 .. code-block:: python
 
@@ -677,7 +677,7 @@ Now let's print out the point geometries:
     lyr = inDataSource.GetLayer('example')
     for feat in lyr:
         geom = feat.GetGeometryRef()
-        print geom.ExportToWkt()
+        print(geom.ExportToWkt())
 
 
 Create a new Layer from the extent of an existing Layer
@@ -1044,7 +1044,7 @@ The `ogr2ogr command line tool <http://www.gdal.org/ogr2ogr.html>`_ is an easy w
     if __name__ == '__main__':
         
         if len( sys.argv ) < 2:
-            print "[ ERROR ]: you need to pass at least one arg -- the field_names to include in output"
+            print("[ ERROR ]: you need to pass at least one arg -- the field_names to include in output")
             sys.exit(1)
         
         main( sys.argv[1:] )
@@ -1075,7 +1075,7 @@ This recipe merges OGR Layers within a directory. Files can be specfied based on
 
     for file in fileList:
         if file.startswith(fileStartsWith) and file.endswith(fileEndsWith):
-            print file
+            print(file)
             ds = ogr.Open(directory+file)
             lyr = ds.GetLayer()
             for feat in lyr:
@@ -1105,7 +1105,7 @@ This recipe takes in an OSM file and prints a list of all the names of the stree
             if name != None and name not in nameList: # only streets that have a name and are not yet in the list
                 nameList.append(name)
 
-    print nameList
+    print(nameList)
     
     
 Create fishnet grid
@@ -1200,7 +1200,7 @@ This recipe creates a fishnet grid.
         #
     
         if len( sys.argv ) != 8:
-            print "[ ERROR ] you must supply seven arguments: output-shapefile-name.shp xmin xmax ymin ymax gridHeight gridWidth"
+            print("[ ERROR ] you must supply seven arguments: output-shapefile-name.shp xmin xmax ymin ymax gridHeight gridWidth")
             sys.exit( 1 )
 
         main( sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7] )
@@ -1390,7 +1390,7 @@ This recipe converts a vector layer to an array.
 
     # Read as array
     array = band.ReadAsArray()
-    print array
+    print(array)
 
 Convert polygon to points
 -------------------


### PR DESCRIPTION
Still an essential python reference, the cookbook snippets would be easier to test and run if the code was compatible with python 2 or 3. 
attn: @pcjericks @jericks 

### Changes include
Replace ```print **args``` with ```print(**args)``` so that snippets in the cookbook will work for python 2 or 3.

### Does not include:
- Checks for iterator safety (range, iteritems, etc.) Willing to add these in a follow-up change

-  references to ```print >> sys.stderr **args`` in vector_layers.rst.
Options include:
1. leave it as-is (python 2 only)
2. ```print("fatal error", file=sys.stderr)``` (python 3 only)
3. ```from __future__ import print_function ; print("fatal error", file=sys.stderr)``` (works for 2 or 3 but requires import in the cookbook
```
$ git grep stderr
vector_layers.rst:            print >> sys.stderr, '[ ERROR ]: layer name = "%s" could not be found in database "%s"' % ( lyr_name, databaseName )
vector_layers.rst:            print >> sys.stderr, '[ ERROR ]: you must pass at least one argument -- the layer name argument'
vector_layers.rst:            print >> sys.stderr, '[ ERROR ]: layer name = "%s" could not be found in database "%s"' % ( lyr_name, databaseName )
vector_layers.rst:            print >> sys.stderr, '[ ERROR ]: you must pass at least one argument -- the layer name argument'
vector_layers.rst:            print >> sys.stderr, '[ ERROR ]: layer name = "%s" could not be found in database "%s"' % ( lyr_name, databaseName )
vector_layers.rst:            print >> sys.stderr, '[ ERROR ]: you must pass at least one argument -- the layer name argument'
```