### PR TITLE
docs: Fix a few typos

### DIFF
--- a/raster_layers.rst
+++ b/raster_layers.rst
@@ -157,7 +157,7 @@ Polygonize a Raster Band
 
 Turn a single raster band into a vector polygon!
 
-If you haven't before, notice that some of the `gdal utilties <http://www.gdal.org/gdal_utilities.html>`_ 
+If you haven't before, notice that some of the `gdal utilities <http://www.gdal.org/gdal_utilities.html>`_ 
 are actually Python scripts. Go find them on your computer, read the source code and mine them for API tricks.
 It turns out the `gdal_polygonize utility <http://www.gdal.org/gdal_polygonize.html>`_ 
 just wraps a call to `GDALFPolygonize <http://www.gdal.org/gdal__alg_8h.html#a3f522a9035d3512b5d414fb4752671b1>`_

--- a/vector_layers.rst
+++ b/vector_layers.rst
@@ -1051,7 +1051,7 @@ The `ogr2ogr command line tool <http://www.gdal.org/ogr2ogr.html>`_ is an easy w
         
 Merge OGR Layers
 -------------------
-This recipe merges OGR Layers within a directory. Files can be specfied based on with what they start and end.
+This recipe merges OGR Layers within a directory. Files can be specified based on with what they start and end.
 
 .. code-block:: python      
         
@@ -1208,7 +1208,7 @@ This recipe creates a fishnet grid.
     
 Convert polygon shapefile to line shapefile
 -------------------
-This recipe converts a poylgon shapefile to a line shapefile
+This recipe converts a polygon shapefile to a line shapefile
 
 .. code-block:: python    
 


### PR DESCRIPTION
There are small typos in:
- raster_layers.rst
- vector_layers.rst

Fixes:
- Should read `utilities` rather than `utilties`.
- Should read `specified` rather than `specfied`.
- Should read `polygon` rather than `poylgon`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md